### PR TITLE
Fix for upcoming testthat 3.3.0 release

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -58,7 +58,7 @@ test_that("rbind_list works", {
 test_that("tibble dependency is soft", {
   with_mocked_bindings(
     loadable = function(x) FALSE,
-    expect_failure(expect_in("tbl", class(as_data_frame(data.frame()))))
+    expect_equal(class(as_data_frame(data.frame())), "data.frame")
   )
 })
 


### PR DESCRIPTION
`expect_failure()` is now designed specifically for testing custom expectations so I replace it's usage with something a little clearer IMO.